### PR TITLE
🐛 Change `LightningLoggerBase` to `Logger`

### DIFF
--- a/pl_bolts/callbacks/data_monitor.py
+++ b/pl_bolts/callbacks/data_monitor.py
@@ -17,8 +17,7 @@ from pl_bolts.utils.warnings import warn_missing_pkg
 try:
     from pytorch_lightning.loggers import Logger
 except ImportError:
-    from pytorch_lightning.loggers import LightningLoggerBase
-    Logger = LightningLoggerBase
+    from pytorch_lightning.loggers import LightningLoggerBase as Logger
 
 if _WANDB_AVAILABLE:
     import wandb

--- a/pl_bolts/callbacks/data_monitor.py
+++ b/pl_bolts/callbacks/data_monitor.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 import numpy as np
 import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
-from pytorch_lightning.loggers import Logger, TensorBoardLogger, WandbLogger
+from pytorch_lightning.loggers import TensorBoardLogger, WandbLogger
 from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from torch import Tensor, nn
@@ -13,6 +13,12 @@ from torch.utils.hooks import RemovableHandle
 from pl_bolts.utils import _WANDB_AVAILABLE
 from pl_bolts.utils.stability import under_review
 from pl_bolts.utils.warnings import warn_missing_pkg
+
+try:
+    from pytorch_lightning.loggers import Logger
+except ImportError:
+    from pytorch_lightning.loggers import LightningLoggerBase
+    Logger = LightningLoggerBase
 
 if _WANDB_AVAILABLE:
     import wandb

--- a/pl_bolts/callbacks/data_monitor.py
+++ b/pl_bolts/callbacks/data_monitor.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 import numpy as np
 import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
-from pytorch_lightning.loggers import LightningLoggerBase, TensorBoardLogger, WandbLogger
+from pytorch_lightning.loggers import Logger, TensorBoardLogger, WandbLogger
 from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from torch import Tensor, nn
@@ -97,7 +97,7 @@ class DataMonitorBase(Callback):
 
             logger.experiment.log(data={name: wandb.Histogram(tensor)}, commit=False)
 
-    def _is_logger_available(self, logger: LightningLoggerBase) -> bool:
+    def _is_logger_available(self, logger: Logger) -> bool:
         available = True
         if not logger:
             rank_zero_warn("Cannot log histograms because Trainer has no logger.")


### PR DESCRIPTION
## What does this PR do?

Fix `cannot import name 'LightningLoggerBase' from 'pytorch_lightning.loggers'`. Since `pytorch_lightning.loggers.base.LightningLoggerBase` is deprecated over `pytorch_lightning.loggers.base.Logger`.
Fixes #972 

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [ ] Did you verify new and **existing tests** pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
