### PR TITLE
ci: bump CUDA tests to 11.7.1

### DIFF
--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -19,12 +19,12 @@ jobs:
           PYTHON_VERSION: '3.8'
           TORCH_VERSION: '1.13.1'
           CUDA_VERSION_MM: '117'
-          runner_image: "nvidia/cuda:11.7.0-cudnn8-runtime-ubuntu20.04"
+          runner_image: "nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04"
         'torch v2.0 | py3.9':
           PYTHON_VERSION: '3.9'
           TORCH_VERSION: '2.0.1'
           CUDA_VERSION_MM: '117'
-          runner_image: "nvidia/cuda:11.7.0-cudnn8-runtime-ubuntu20.04"
+          runner_image: "nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04"
         'torch v2.0 | py3.10':
           PYTHON_VERSION: '3.10'
           TORCH_VERSION: '2.0.1'


### PR DESCRIPTION
## What does this PR do?

seems like NVIDIA dropped the image

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [ ] Did you verify new and **existing tests** pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview lightning-bolts start -->
----
:books: Documentation preview :books:: https://lightning-bolts--1052.org.readthedocs.build/en/1052/

<!-- readthedocs-preview lightning-bolts end -->